### PR TITLE
Stamp 개선 - Btn 종류에 맞게 찍힘

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,8 @@ const App: FC = () => {
   const [lines, setLines] = useState<LineData[]>([]);
   const [currentColor, setCurrentColor] = useState<string>('#000000');
   const [image, setImage] = useState<HTMLImageElement | null>(null);
-  
+  const [clickedIconBtn, setClickedIconBtn] = useState<string | null>(null);
+
   /*
    * [CRDT] 
    * 2024.01.22
@@ -171,6 +172,10 @@ const App: FC = () => {
   
   let newLine : Konva.Line | null = null;
   let id = uuidv4();
+  
+  const handleIconBtnClick = (id: string) => {
+    setClickedIconBtn(id);  // 클릭한 IconBtn의 id를 clickIconBtn 변수에 저장
+  }
 
   const handleMouseDown = (e: any) => {
     const stage = e.target.getStage()
@@ -362,7 +367,7 @@ const App: FC = () => {
           window.addEventListener('click', handleOutsideClick);
         });
       });
-      setTool(Tools.CORSER)
+      setTool(Tools.CURSOR);
 
     } else if (tool === Tools.PEN) {
       
@@ -446,9 +451,11 @@ const App: FC = () => {
     const pos = stage.getPointerPosition();
     const layers = stage.getLayers();
     const layer = layers[0];
+    
+    if (clickedIconBtn === 'thumbUp' || 'thumbDown') {
+      /* btn에 맞는 이미지 불러오기 */
+      let stampType = clickedIconBtn;
 
-    if (tool === Tools.STAMP) {
-      const stampType = e.currentTarget.id;
       let stampImg = new window.Image();
       stampImg.src = stampType === 'thumbUp' ? thumbUpImg : thumbDownImg;
       
@@ -462,7 +469,10 @@ const App: FC = () => {
         const newStamp = new Konva.Image({
           x: pos.x,
           y: pos.y,
+          width: 40,
+          height: 40,
           image: stampImg,
+          draggable: true,
         });
         isSelected.current = false;
         layer.add(newStamp);
@@ -493,7 +503,7 @@ const App: FC = () => {
 
       </Stage>
       <ColorProvider>
-        <ButtonCustomGroup />
+        <ButtonCustomGroup handleIconBtnClick={handleIconBtnClick} />
       </ColorProvider>
     </div>
   );

--- a/src/component/ButtonCustomGroup.tsx
+++ b/src/component/ButtonCustomGroup.tsx
@@ -13,7 +13,11 @@ import UndoRoundedIcon from '@mui/icons-material/UndoRounded';
 import RedoRoundedIcon from '@mui/icons-material/RedoRounded';
 import CircleIcon from '@mui/icons-material/Circle';
 
-export const ButtonCustomGroup = () =>{
+interface ButtonCustomGroupProps {
+    handleIconBtnClick: (id: string) => void;
+}
+
+export const ButtonCustomGroup = ({handleIconBtnClick}: ButtonCustomGroupProps) =>{
     const { currentColor, setCurrentColor } = useColor();
 
     // 색상 변경
@@ -44,8 +48,8 @@ export const ButtonCustomGroup = () =>{
                 <Button id='eraser'>eraser</Button>
                 <Button id='postit'>postit</Button>
                 <div className='shapeBox'>
-                    <Stamp props={Tools.STAMP} />
-                    <Shape />
+                    <Stamp handleIconBtnClick={handleIconBtnClick}/>
+                    <Shape props={Tools.SHAPE}/>
                 </div>
                 <Button id='mindmap'>mindmap</Button>
                 <Button className='singleColor' onClick={()=>{handleColorClick('#000000')}}><CircleIcon style={{color: '000000'}}/></Button>

--- a/src/component/Stamp.tsx
+++ b/src/component/Stamp.tsx
@@ -1,4 +1,4 @@
-// import { useTool } from './ToolContext';
+import { useTool } from './ToolContext';
 import { Tools } from './Tools';
 // import { useState } from 'react';
 import IconButton from '@mui/material/Button';
@@ -7,22 +7,21 @@ import ThumbDownRoundedIcon from '@mui/icons-material/ThumbDownRounded';
 // import { Image, Stage } from 'react-konva';
 // import thumbUpImg from '../thumbup.png';
 // import thumbDownImg from '../thumbdown.png'
-import { useTool } from './ToolContext';
 
 interface StampProps {
-    props: Tools;
+    handleIconBtnClick: (e: any) => void;
 }
 
-export default function Stamp({ props }: StampProps){
+export default function Stamp({ handleIconBtnClick }: StampProps){
     const { setTool } = useTool();
 
     return(
         <>
-            <IconButton aria-label="thumb up" id="thumbUp" onClick={()=>{setTool(props)}}>
+            <IconButton aria-label="thumb up" id="thumbUp" onClick={()=>{handleIconBtnClick("thumbUp")}}>
                 <ThumbUpAltRoundedIcon />
             </IconButton>
 
-            <IconButton aria-label="thumb down" id="thumbDown" onClick={()=>{setTool(props)}}>
+            <IconButton aria-label="thumb down" id="thumbDown" onClick={()=>{handleIconBtnClick("thumbDown")}}>
                 <ThumbDownRoundedIcon />
             </IconButton>
         </>

--- a/src/component/Tools.ts
+++ b/src/component/Tools.ts
@@ -7,5 +7,5 @@ export enum Tools{
     "SHAPE",
     "STAMP",
     "MINDMAP",
-    "CORSER"
+    "CURSOR"
   }


### PR DESCRIPTION
개선 내용
1. thumbup/thumbdown 아이콘 누른 후 화면 클릭하면 항상 thumbdown 스탬프 찍혔는데, 각 아이콘에 맞는 스탬프 찍히도록 개선함. (노션에 트러블슈팅 적어놨습니다)

보완할 사항
1. btn 선택 후 stage 처음 클릭할 때 스탬프 안찍힘
2. 스탬프 한번 찍은 후 재클릭하면 동일한 스탬프 계속 찍힘. `isSelected.current = false;` 적용 안되는듯
3. 사이즈 조정 미구현
4. 커서 위치 조정 필요 (이미지 한가운데로. 현재 이미지 왼쪽 상단.)
5. draggable -> 스탬프 옮기면 mousedown할 때 펜 찍힘 (Tools.STAMP 상태일때도 그랬음)(현재 코드엔 Tools.STAMP 없앰)