### PR TITLE
Stamp 개선 - Tools.STAMP 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,7 @@ const App: FC = () => {
 
   const stageRef = useRef(null);
   const isDrawing = useRef(false);
-  const isSelected = useRef(false);
+  const isToolSelected = useRef(false);
 
   // Y.js 관련 상태를 useRef로 관리
   const yDocRef = useRef(new Y.Doc());
@@ -452,30 +452,32 @@ const App: FC = () => {
     const layers = stage.getLayers();
     const layer = layers[0];
     
-    if (clickedIconBtn === 'thumbUp' || 'thumbDown') {
-      /* btn에 맞는 이미지 불러오기 */
-      let stampType = clickedIconBtn;
-
-      let stampImg = new window.Image();
-      stampImg.src = stampType === 'thumbUp' ? thumbUpImg : thumbDownImg;
-      
-      stampImg.onload = () => {
-        setImage(stampImg);
-        isSelected.current = true;
-      }
-
-      /* 클릭 위치에 스탬프 찍기 */
-      if (isSelected.current) {
-        const newStamp = new Konva.Image({
-          x: pos.x,
-          y: pos.y,
-          width: 40,
-          height: 40,
-          image: stampImg,
-          draggable: true,
-        });
-        isSelected.current = false;
-        layer.add(newStamp);
+    if(tool === Tools.STAMP){
+      if (clickedIconBtn === 'thumbUp' || 'thumbDown') {
+        /* btn에 맞는 이미지 불러오기 */
+        let stampType = clickedIconBtn;
+  
+        let stampImg = new window.Image();
+        stampImg.src = stampType === 'thumbUp' ? thumbUpImg : thumbDownImg;
+        
+        stampImg.onload = () => {
+          setImage(stampImg);
+          isToolSelected.current = true;
+        }
+  
+        /* 클릭 위치에 스탬프 찍기 */
+        if (isToolSelected.current) {
+          const newStamp = new Konva.Image({
+            x: pos.x,
+            y: pos.y,
+            width: 40,
+            height: 40,
+            image: stampImg,
+            draggable: true,
+          });
+          isToolSelected.current = false;
+          layer.add(newStamp);
+        }
       }
     }
   };

--- a/src/component/ButtonCustomGroup.tsx
+++ b/src/component/ButtonCustomGroup.tsx
@@ -48,7 +48,7 @@ export const ButtonCustomGroup = ({handleIconBtnClick}: ButtonCustomGroupProps) 
                 <Button id='eraser'>eraser</Button>
                 <Button id='postit'>postit</Button>
                 <div className='shapeBox'>
-                    <Stamp handleIconBtnClick={handleIconBtnClick}/>
+                    <Stamp handleIconBtnClick={handleIconBtnClick} props={Tools.STAMP}/>
                     <Shape props={Tools.SHAPE}/>
                 </div>
                 <Button id='mindmap'>mindmap</Button>

--- a/src/component/Stamp.tsx
+++ b/src/component/Stamp.tsx
@@ -10,18 +10,29 @@ import ThumbDownRoundedIcon from '@mui/icons-material/ThumbDownRounded';
 
 interface StampProps {
     handleIconBtnClick: (e: any) => void;
+    props: Tools;
 }
 
-export default function Stamp({ handleIconBtnClick }: StampProps){
+export default function Stamp({ handleIconBtnClick, props }: StampProps){
     const { setTool } = useTool();
+
+    interface components {
+        name : string
+        id : string
+    }
+
+    const componentElem : components = {
+        name : Tools[props].toString(),
+        id : Tools[props].toString()
+    }
 
     return(
         <>
-            <IconButton aria-label="thumb up" id="thumbUp" onClick={()=>{handleIconBtnClick("thumbUp")}}>
+            <IconButton aria-label="thumb up" id={componentElem.id} onClick={()=>{handleIconBtnClick("thumbUp"); setTool(props);}}>
                 <ThumbUpAltRoundedIcon />
             </IconButton>
 
-            <IconButton aria-label="thumb down" id="thumbDown" onClick={()=>{handleIconBtnClick("thumbDown")}}>
+            <IconButton aria-label="thumb down" id={componentElem.id} onClick={()=>{handleIconBtnClick("thumbDown"); setTool(props);}}>
                 <ThumbDownRoundedIcon />
             </IconButton>
         </>


### PR DESCRIPTION
### trouble
![image](https://github.com/Potato-Field/live-board/assets/80061287/bb37bc2d-1048-443f-8d9a-676b54bf8007)

### 해결 방안
- IconButton에 `id={componentElem.id}` 부여

### 개선 결과
- stamp 버튼 누르고 화면 클릭하면 펜 드로잉 되지 않음
- stamp 외의 Tool 사용시 스탬프 add 되지 않음 (온전히 tool 사용 가능)