### PR TITLE
tool bar 텍스트->아이콘으로 변경 (지우개 마인드맵 제외)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,10 @@
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-regular-svg-icons": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@mui/icons-material": "^5.15.6",
         "@mui/material": "^5.15.5",
         "@mui/styled-engine-sc": "^6.0.0-alpha.12",
@@ -1067,6 +1071,63 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-m6ShXn+wvqEU69wSP84coxLbNl7sGVZb+Ca+XZq6k30SzuP3X4TfPqtycgUh9ASwlNh5OfQCd8pDIWxl+O+LlQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-regular-svg-icons": "^6.5.1",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.5",
     "@mui/styled-engine-sc": "^6.0.0-alpha.12",

--- a/src/component/ButtonCustomGroup.tsx
+++ b/src/component/ButtonCustomGroup.tsx
@@ -1,10 +1,12 @@
 import { Tools } from './Tools';
 import { useColor } from './ColorContext';
+import Hand from './Hand';
+import Cursor from './Cursor';
+import Text from './Text';
+import Pen from './Pen';
+import PostIt from './PostIt';
 import Stamp from './Stamp';
 import Shape from './Shape';
-import Pen from './Pen';
-import Text from './Text';
-import Cursor from './Cursor';
 
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
@@ -12,8 +14,8 @@ import { MuiColorInput } from 'mui-color-input'
 import { IconButton } from '@mui/material';
 import UndoRoundedIcon from '@mui/icons-material/UndoRounded';
 import RedoRoundedIcon from '@mui/icons-material/RedoRounded';
+import { faPen, faHighlighter } from '@fortawesome/free-solid-svg-icons'
 import CircleIcon from '@mui/icons-material/Circle';
-import Hand from './Hand';
 
 interface ButtonCustomGroupProps {
     handleIconBtnClick: (id: string) => void;
@@ -43,14 +45,15 @@ export const ButtonCustomGroup = ({handleIconBtnClick}: ButtonCustomGroupProps) 
                         } 
                     */
                 }
-                <Hand props = {Tools.HAND}/>
-                <Cursor props = {Tools.CURSOR}/>
+                <div className='cursorBox'>
+                    <Hand props = {Tools.HAND}/>
+                    <Cursor props = {Tools.CURSOR}/>
+                </div>
                 <Text   props = {Tools.TEXT}/>
-                <Pen    props = {Tools.PEN}/>
-                <Pen    props = {Tools.HIGHLIGHTER}/>
-
+                <Pen    props = {Tools.PEN} icon = {faPen}/>
+                <Pen    props = {Tools.HIGHLIGHTER} icon = {faHighlighter}/>
                 <Button id='eraser'>eraser</Button>
-                <Button id='postit'>postit</Button>
+                <PostIt handleIconBtnClick={handleIconBtnClick} props={Tools.POSTIT}/>
                 <div className='shapeBox'>
                     <Stamp handleIconBtnClick={handleIconBtnClick} props={Tools.STAMP}/>
                     <Shape handleIconBtnClick={handleIconBtnClick} props={Tools.SHAPE}/>

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -1,4 +1,6 @@
 import Button from '@mui/material/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faArrowPointer } from '@fortawesome/free-solid-svg-icons'
 import { useTool } from './ToolContext';
 import { Tools } from './Tools';
 
@@ -21,8 +23,9 @@ export default function Cursor({ props }:CursorProps){
 
     return(
         <>
-            <Button id={componentElem.id} onClick={()=>{setTool(props)}}>{componentElem.name}</Button>
+            <Button id={componentElem.id} onClick={()=>{setTool(props)}}>
+                <FontAwesomeIcon icon={faArrowPointer} size='xl' />
+            </Button>
         </>
     );
-
 }

--- a/src/component/Hand.tsx
+++ b/src/component/Hand.tsx
@@ -1,4 +1,6 @@
 import Button from '@mui/material/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faHand } from '@fortawesome/free-regular-svg-icons'
 import { useTool } from './ToolContext';
 import { Tools } from './Tools';
 
@@ -21,8 +23,9 @@ export default function Hand({ props }:HandProps){
 
     return(
         <>
-            <Button id={componentElem.id} onClick={()=>{setTool(props)}}>{componentElem.name}</Button>
+            <Button id={componentElem.id} onClick={()=>{setTool(props)}}>
+                <FontAwesomeIcon icon={faHand} size='xl' />    
+            </Button>
         </>
     );
-
 }

--- a/src/component/Pen.tsx
+++ b/src/component/Pen.tsx
@@ -1,4 +1,6 @@
 import Button from '@mui/material/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { useTool } from './ToolContext';
 import { Tools } from './Tools';
 
@@ -10,9 +12,10 @@ interface PenProps {
         바로 쓰려면 interface를 생성해서 타입 지정해주고 받아야 하는 듯
     */
     props: Tools;
+    icon: IconProp;
 }
 
-export default function Pen({ props }:PenProps){
+export default function Pen({ props, icon }:PenProps){
     const { setTool } = useTool();
     
     interface components {
@@ -22,13 +25,14 @@ export default function Pen({ props }:PenProps){
 
     const componentElem : components = {
         name : Tools[props].toString(),
-        id : Tools[props].toString()
+        id : Tools[props].toString(),
     }
 
     return(
         <>
-            <Button id={componentElem.id} onClick={()=>{setTool(props)}}>{componentElem.name}</Button>
+            <Button id={componentElem.id} onClick={()=>{setTool(props)}}>
+                <FontAwesomeIcon icon={icon} size='2xl' />
+            </Button>
         </>
     );
-
 }

--- a/src/component/PostIt.tsx
+++ b/src/component/PostIt.tsx
@@ -1,0 +1,31 @@
+import { Tools } from './Tools';
+import { useTool } from './ToolContext';
+import IconButton from '@mui/material/Button';
+import StickyNote2RoundedIcon from '@mui/icons-material/StickyNote2Rounded';
+
+interface PostItProps {
+    handleIconBtnClick: (e: any) => void;
+    props: Tools;
+}
+
+export default function PostIt({ handleIconBtnClick, props }:PostItProps) {
+    const { setTool } = useTool();
+
+    interface components {
+        name : string
+        id : string
+    }
+
+    const componentElem : components = {
+        name : Tools[props].toString(),
+        id : Tools[props].toString()
+    }
+
+    return(
+        <>
+            <IconButton id={componentElem.id} onClick={()=>{handleIconBtnClick("postit"); setTool(props);}}>
+                <StickyNote2RoundedIcon fontSize='large'/>
+            </IconButton>
+        </>                                                               
+    );
+}

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -1,4 +1,6 @@
 import Button from '@mui/material/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFont } from '@fortawesome/free-solid-svg-icons'
 import { useTool } from './ToolContext';
 import { Tools } from './Tools';
 
@@ -21,8 +23,9 @@ export default function Text({ props }:TextProps){
 
     return(
         <>
-            <Button id={componentElem.id} onClick={()=>{setTool(props)}}>{componentElem.name}</Button>
+            <Button id={componentElem.id} onClick={()=>{setTool(props)}}>
+                <FontAwesomeIcon icon={faFont} size='2xl' />
+            </Button>
         </>
     );
-
 }


### PR DESCRIPTION
ui 지금 리를빗 엉망진창 하우에버 발표 전까지 깔꼼하게 수정 예정
![image](https://github.com/Potato-Field/live-board/assets/80061287/098e64b0-72ec-4ac9-bc5f-f5d98cfe729a)
